### PR TITLE
Fix imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,4 @@
+import os
+import sys
+fpath = os.path.join(os.path.dirname(__file__))
+sys.path.append(fpath)

--- a/models.py
+++ b/models.py
@@ -86,7 +86,7 @@ class CNN_SxF(encoding_model):
             mean_activity=self.config["mean_activity"],
             gamma_readout=self.config["readout_gamma"],
         )
-        self.register_buffer("laplace", torch.from_numpy(laplace))
+        self.register_buffer("laplace", torch.from_numpy(laplace()))
         self.nonlin = bl.act_func()["softplus"]
 
     def forward(self, x):


### PR DESCRIPTION
**Motivation**
When you import predict_neural_responses from some other module, the whole module "collapses". Why? The path in PYTHONPATH is the path from which you run your script (outside of predict_neural_responses) and therefore predict_neural_responses path is not in the PYTHONPATH. In predict_neural_responses, we used `import dnn_blocks.dnn_blocks as bl`, which stops working as dnn_blocks is not in path (predict_neural_responses would have to be in path which is not).

**Fix**
We added `__init__.py` file, which is a file that gets executed, whenever you import a package (in our case predict_neural_responses). In this file, we add predict_neural_responses to the PYTHONPATH. Now, the imports in predict_neural_responses will work :)